### PR TITLE
Refactor record navigation to update in-place instead of redirecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package will automatically register itself.
 
 ### Use the Trait in Your Filament Resource Page
 
-In your Filament resource's `EditRecord` page, use the `HasRecordNavigation` trait to add the navigation functionality. And add the action where you want, for example the header:
+In your Filament resource's `EditRecord` page, use the `HasRecordNavigation` trait to add the navigation functionality. And add the action where you want, for example, the header with `getHeaderActions`:
 
 ```php
 namespace App\Filament\Resources\PostResource\Pages;
@@ -40,6 +40,7 @@ class EditPost extends EditRecord
 }
 ```
 
+### Use with existing actions
 If you have existing actions, merge them with the navigation actions, like so:
 
 ```php
@@ -55,27 +56,20 @@ protected function getHeaderActions(): array
 
 ### Store Record IDs in Session
 
-In your resource's `ListRecords` page, store the record IDs in the session to enable navigation. Make sure it's called "filament_record_navigation_ids":
+In your resource's `ListRecords` page, include the `HasRecordsList` trait as follows:
 
 ```php
 namespace App\Filament\Resources\PostResource\Pages;
 
 use App\Filament\Resources\PostResource;
 use Filament\Resources\Pages\ListRecords;
+use JoseEspinal\RecordNavigation\Traits\HasRecordsList;
 
 class ListPosts extends ListRecords
 {
+    use HasRecordsList;
+
     protected static string $resource = PostResource::class;
-
-    protected function getTableQuery()
-    {
-        $query = parent::getTableQuery();
-
-        // Store record IDs in session
-        session(['filament_record_navigation_ids' => $query->pluck('id')->toArray()]);
-
-        return $query;
-    }
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "autoload": {
         "psr-4": {
-            "JoseEspinal\\RecordNavigation\\": "src/",
+            "JoseEspinal\\RecordNavigation\\": "src/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     "autoload": {
         "psr-4": {
             "JoseEspinal\\RecordNavigation\\": "src/",
-            "JoseEspinal\\RecordNavigation\\Database\\Factories\\": "database/factories/"
         }
     },
     "autoload-dev": {
@@ -73,10 +72,7 @@
         "laravel": {
             "providers": [
                 "JoseEspinal\\RecordNavigation\\RecordNavigationServiceProvider"
-            ],
-            "aliases": {
-                "RecordNavigation": "JoseEspinal\\RecordNavigation\\Facades\\RecordNavigation"
-            }
+            ]
         }
     },
     "minimum-stability": "dev",

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -56,12 +56,12 @@ trait HasRecordNavigation
             Action::make('Previous')
                 ->action('previousRecord')
                 ->color('gray')
-                ->icon('heroicon-m-chevron-left')
+                ->icon('heroicon-s-chevron-left')
                 ->iconButton(),
             Action::make('Next')
                 ->action('nextRecord')
                 ->color('gray')
-                ->icon('heroicon-m-chevron-right')
+                ->icon('heroicon-s-chevron-right')
                 ->iconButton(),
         ]);
     }

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -20,7 +20,9 @@ trait HasRecordNavigation
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex + 1])) {
-            return redirect()->route(static::getRouteName(), ['record' => $ids[$currentIndex + 1]]);
+            $this->recordId = $ids[$currentIndex + 1];
+            $this->initializeRecord();
+            $this->mount($this->recordId);
         }
     }
 
@@ -30,8 +32,22 @@ trait HasRecordNavigation
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex - 1])) {
-            return redirect()->route(static::getRouteName(), ['record' => $ids[$currentIndex - 1]]);
+            $this->recordId = $ids[$currentIndex - 1];
+            $this->initializeRecord();
+            $this->mount($this->recordId);
         }
+    }
+
+    public function initializeRecord()
+    {
+        $this->record = $this->loadModel();
+    }
+
+    protected function loadModel()
+    {
+        $modelClass = static::$resource::getModel();
+
+        return $modelClass::find($this->recordId);
     }
 
     protected function getNavigationActions(): array

--- a/src/Traits/HasRecordsList.php
+++ b/src/Traits/HasRecordsList.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace JoseEspinal\RecordNavigation\Traits;
+
+trait HasRecordsList
+{
+    public function rendered($view, $html)
+    {
+        $query = static::getResource()::getEloquentQuery();
+        $data = $this->tableFilters;
+        $filters = $this->getTable()->getFilters();
+
+        foreach ($filters as $filter) {
+            $filter->apply(
+                $query,
+                $data[$filter->getName()] ?? [],
+            );
+        }
+
+        // Store record IDs in session
+        session(['filament_record_navigation_ids' => $query->pluck('id')->toArray()]);
+
+        return $query;
+    }
+}


### PR DESCRIPTION
- Replace redirection on HasRecordNavigation's nextRecord and previousRecord methods with direct record updates.
- Add initializeRecord and loadModel methods to refresh the component's record after navigation.
- Update nextRecord and previousRecord to set recordId, call initializeRecord, and re-mount the component with the new recordId.
- Ensure that record navigation now seamlessly updates the UI without a full page reload.