### PR TITLE
Release for version 2.1.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,11 +19,13 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2]
         laravel: [10.*]
+        filament: [3.0]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+            filament: ^3.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -45,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" "filament/filament:${{ matrix.filament }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `filament-record-navigation` will be documented in this file.
 
-## v2.1.0 - 2024-03-21
+## v2.1.0 - 2025-04-11
 
 ### Added
 - Unsaved changes confirmation before record navigation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `filament-record-navigation` will be documented in this file.
 
+## v2.1.0 - 2024-03-21
+
+### Added
+- Unsaved changes confirmation before record navigation
+- Support for Laravel 12
+- Browser history management for record navigation
+- Proper Filament asset registration
+- Enhanced event handling for navigation state
+
+### Changed
+- Updated dependencies to ensure compatibility with Laravel 12
+- Migrated from `Filament\Pages\Actions\Action` to `Filament\Actions\Action`
+- Improved navigation UX with proper URL updates
+
+**Full Changelog**: https://github.com/josespinal/filament-record-navigation/compare/v2.0.4...v2.1.0
+
 ## v2.0.4 - 2024-06-07
 
 Replace redirection in nextRecord and previousRecord methods with direct record update. This provides a better UX as there are no visual flashing between record changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,43 +2,32 @@
 
 All notable changes to `filament-record-navigation` will be documented in this file.
 
-## v2.2.0 - 2024-03-21
+## v2.1.0 - 2025-04-12
 
 ### Added
-- Added proper type hints and return types
-- Added comprehensive PHPDoc documentation
-- Added `url` property for better URL management
-- Added `initializeProperties` method for better code organization
+- Enhanced record navigation actions with session-based visibility
+- Added data change tracking and confirmation dialog for unsaved changes
+- Added CSS attributes for easier styling of navigation buttons
 
 ### Changed
-- Improved code organization and maintainability
-- Refactored record initialization logic
-- Made internal methods private for better encapsulation
-- Improved type safety with proper type declarations
-- Enhanced record navigation state management
+- Renamed event listeners for consistency and clarity
+- Updated properties to better reflect their purpose, including changing `isViewRecord` to `isViewPage`
+- Improved documentation to clarify customization of unsaved changes confirmation message
 
-### Fixed
-- Fixed potential type issues with record IDs
-- Improved handling of record navigation state
-- Better integration with Filament's unsaved changes alert
-
-**Full Changelog**: https://github.com/josespinal/filament-record-navigation/compare/v2.1.0...v2.2.0
-
-## v2.1.0 - 2025-04-11
-
-### Added
-- Unsaved changes confirmation before record navigation
-- Support for Laravel 12
-- Browser history management for record navigation
-- Proper Filament asset registration
-- Enhanced event handling for navigation state
-
-### Changed
-- Updated dependencies to ensure compatibility with Laravel 12
-- Migrated from `Filament\Pages\Actions\Action` to `Filament\Actions\Action`
-- Improved navigation UX with proper URL updates
+### Dev
+- Updated GitHub Actions workflow to include Filament 3.0 in test matrix
 
 **Full Changelog**: https://github.com/josespinal/filament-record-navigation/compare/v2.0.4...v2.1.0
+
+## v2.0.5 - 2025-04-12
+
+### Added
+- Added support for Laravel 12
+
+### Changed
+- Ensured compatibility with the latest Laravel version
+- Improved stability and performance
+- Updated dependencies for better compatibility
 
 ## v2.0.4 - 2024-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to `filament-record-navigation` will be documented in this file.
 
+## v2.2.0 - 2024-03-21
+
+### Added
+- Added proper type hints and return types
+- Added comprehensive PHPDoc documentation
+- Added `url` property for better URL management
+- Added `initializeProperties` method for better code organization
+
+### Changed
+- Improved code organization and maintainability
+- Refactored record initialization logic
+- Made internal methods private for better encapsulation
+- Improved type safety with proper type declarations
+- Enhanced record navigation state management
+
+### Fixed
+- Fixed potential type issues with record IDs
+- Improved handling of record navigation state
+- Better integration with Filament's unsaved changes alert
+
+**Full Changelog**: https://github.com/josespinal/filament-record-navigation/compare/v2.1.0...v2.2.0
+
 ## v2.1.0 - 2025-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,19 +106,7 @@ No additional configuration is needed - this feature works out of the box.
 
 #### Customizing the Confirmation Message
 
-To customize the unsaved changes confirmation message, you can publish the JavaScript asset and modify it:
-
-```bash
-php artisan vendor:publish --tag=filament-record-navigation-assets
-```
-
-Then edit the confirmation message in `resources/js/vendor/filament-record-navigation/filament-record-navigation.js`:
-
-```javascript
-if (!confirm('Your custom message here')) {
-    return;
-}
-```
+By default, this uses Filament's translation key `filament-panels::unsaved-changes-alert.body`. You can customize this message by publishing Filament's translations and modifying the corresponding translation string.
 
 Remember to rebuild your assets after making changes.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 ## Introduction
 
-The **Filament Record Navigation Plugin** allows seamless navigation through records in a Filament resource's view. With this plugin, you can add "Next" and "Previous" buttons to navigate through records efficiently.
+The **Filament Record Navigation Plugin** allows seamless navigation through records in a Filament resource's view. With this plugin, you can add "Next" and "Previous" buttons to navigate through records efficiently. It includes features like unsaved changes detection, browser history management, and proper URL updates.
 
 https://github.com/josespinal/filament-record-navigation/assets/10059/fbb09144-b0b5-411d-85a8-1d94eedcad01
+
+## Features
+
+- Navigate between records with "Next" and "Previous" buttons
+- Unsaved changes detection with confirmation dialog
+- Browser history management for proper navigation state
+- Seamless URL updates without page refresh
+- Support for Laravel 10, 11, and 12
+- Compatible with Filament v3.x
 
 ## Installation
 
@@ -15,6 +24,20 @@ composer require josespinal/filament-record-navigation
 ```
 
 The package will automatically register itself.
+
+### Step 2: Publish Filament Assets
+
+After installation, you need to publish and build the Filament assets:
+
+```bash
+php artisan filament:assets
+```
+
+For production environments, make sure to run:
+
+```bash
+php artisan filament:assets --optimize
+```
 
 ## Usage
 
@@ -74,6 +97,37 @@ class ListPosts extends ListRecords
     protected static string $resource = PostResource::class;
 }
 ```
+
+### Unsaved Changes Detection
+
+The plugin automatically detects unsaved changes in your forms and will prompt for confirmation before navigating away. This helps prevent accidental data loss when navigating between records.
+
+No additional configuration is needed - this feature works out of the box.
+
+#### Customizing the Confirmation Message
+
+To customize the unsaved changes confirmation message, you can publish the JavaScript asset and modify it:
+
+```bash
+php artisan vendor:publish --tag=filament-record-navigation-assets
+```
+
+Then edit the confirmation message in `resources/js/vendor/filament-record-navigation/filament-record-navigation.js`:
+
+```javascript
+if (!confirm('Your custom message here')) {
+    return;
+}
+```
+
+Remember to rebuild your assets after making changes.
+
+## Browser Support
+
+The plugin uses modern browser features for enhanced navigation:
+- History API for proper browser history management
+- URL updates without page refresh
+- Works with all modern browsers (Chrome, Firefox, Safari, Edge)
 
 ## Changelog
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^10.0||^11.0"
+        "illuminate/contracts": "^10.0||^11.0",
+        "filament/support": "^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",

--- a/resources/dist/js/filament-record-navigation.js
+++ b/resources/dist/js/filament-record-navigation.js
@@ -1,0 +1,13 @@
+document.addEventListener('nextRecord', (event) => {
+  const { recordId, url } = event.detail[0];
+
+  // Update browser history without page refresh
+  window.history.pushState({ recordId }, '', url);
+});
+
+document.addEventListener('previousRecord', (event) => {
+  const { recordId, url } = event.detail[0];
+
+  // Update browser history without page refresh
+  window.history.pushState({ recordId }, '', url);
+});

--- a/resources/dist/js/filament-record-navigation.js
+++ b/resources/dist/js/filament-record-navigation.js
@@ -1,6 +1,13 @@
 document.addEventListener('nextRecord', (event) => {
   const { recordId, url } = event.detail[0];
 
+  // Check for unsaved changes before navigation
+  if (hasUnsavedChanges()) {
+    if (!confirm('You have unsaved changes. Are you sure you want to leave this page?')) {
+      return;
+    }
+  }
+
   // Update browser history without page refresh
   window.history.pushState({ recordId }, '', url);
 });
@@ -8,6 +15,32 @@ document.addEventListener('nextRecord', (event) => {
 document.addEventListener('previousRecord', (event) => {
   const { recordId, url } = event.detail[0];
 
+  // Check for unsaved changes before navigation
+  if (hasUnsavedChanges()) {
+    if (!confirm('You have unsaved changes. Are you sure you want to leave this page?')) {
+      return;
+    }
+  }
+
   // Update browser history without page refresh
   window.history.pushState({ recordId }, '', url);
 });
+
+function hasUnsavedChanges() {
+  // Check if there are any mounted actions or forms
+  const livewireComponent = window.Livewire?.find(document.querySelector('[wire\\:id]')?.getAttribute('wire:id'));
+
+  if (!livewireComponent) {
+    return false;
+  }
+
+  const hasMountedActions = [
+    ...(Array.isArray(livewireComponent.mountedActions) ? livewireComponent.mountedActions : []),
+    ...(Array.isArray(livewireComponent.mountedFormComponentActions) ? livewireComponent.mountedFormComponentActions : []),
+    ...(Array.isArray(livewireComponent.mountedInfolistActions) ? livewireComponent.mountedInfolistActions : []),
+    ...(Array.isArray(livewireComponent.mountedTableActions) ? livewireComponent.mountedTableActions : []),
+    ...(livewireComponent.mountedTableBulkAction ? [livewireComponent.mountedTableBulkAction] : []),
+  ].length > 0;
+
+  return hasMountedActions && !livewireComponent.__instance?.effects?.redirect;
+}

--- a/resources/dist/js/filament-record-navigation.js
+++ b/resources/dist/js/filament-record-navigation.js
@@ -17,10 +17,7 @@ window.addEventListener("popstate", (event) => {
 // we need to update the browser history
 document.addEventListener('changeNavigationRecord', (event) => {
   const { recordId, url, isViewRecord, componentId, confirmMessage } = event.detail[0];
-
   const component = Livewire.find(componentId);
-
-  console.log(component.data, isViewRecord);
 
   if (!isViewRecord) {
     if (

--- a/resources/dist/js/filament-record-navigation.js
+++ b/resources/dist/js/filament-record-navigation.js
@@ -1,6 +1,6 @@
 // When the user navigates to the first record, 
 // we need to set the browser history
-document.addEventListener('start-record-navigation', (event) => {
+document.addEventListener('startRecordNavigation', (event) => {
   const { recordId, url } = event.detail[0];
   window.history.replaceState({ recordId }, '', url);
 });
@@ -9,32 +9,25 @@ document.addEventListener('start-record-navigation', (event) => {
 // we need to update the record
 window.addEventListener("popstate", (event) => {
   if (event.state) {
-    Livewire.dispatch('execute-change-record', { 'recordId': event.state.recordId });
+    Livewire.dispatch('executeChangeRecord', { 'recordId': event.state.recordId });
   }
 });
 
 // When the user navigates to a new record with the filament navigation, 
 // we need to update the browser history
 document.addEventListener('changeNavigationRecord', (event) => {
-  const { recordId, url, isViewRecord, componentId, confirmMessage } = event.detail[0];
-  const component = Livewire.find(componentId);
+  const { recordId, url, isViewPage, confirmMessage, isDataDirty } = event.detail[0];
 
-  if (!isViewRecord) {
-    if (
-      window.jsMd5(
-        JSON.stringify(component.data).replace(/\\/g, ''),
-      ) !== component.savedDataHash ||
-      component?.__instance?.effects?.redirect
-    ) {
+  if (!isViewPage) {
+    if (isDataDirty) {
       if (confirm(confirmMessage)) {
         window.history.pushState({ recordId }, '', url);
-        component.executeChangeRecord(recordId);
+        Livewire.dispatch('executeChangeRecord', { 'recordId': recordId });
       }
       return;
     }
   }
 
-
   window.history.pushState({ recordId }, '', url);
-  component.executeChangeRecord(recordId);
-});
+  Livewire.dispatch('executeChangeRecord', { 'recordId': recordId });
+}); 

--- a/resources/views/components/record-navigation-buttons.blade.php
+++ b/resources/views/components/record-navigation-buttons.blade.php
@@ -1,4 +1,4 @@
-<div class="flex justify-between mb-4">
+<div data-record-navigation-buttons class="flex justify-between mb-4">
     <x-filament::button wire:click="previousRecord">Previous</x-filament::button>
     <x-filament::button wire:click="nextRecord">Next</x-filament::button>
 </div>

--- a/src/RecordNavigationServiceProvider.php
+++ b/src/RecordNavigationServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace JoseEspinal\RecordNavigation;
 
+use Filament\Support\Assets\Js;
+use Filament\Support\Facades\FilamentAsset;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -15,5 +17,13 @@ class RecordNavigationServiceProvider extends PackageServiceProvider
         $package
             ->name('filament-record-navigation')
             ->hasViews();
+    }
+
+    public function packageBooted(): void
+    {
+        // Register as a Filament asset
+        FilamentAsset::register([
+            Js::make('filament-record-navigation', __DIR__ . '/../resources/dist/js/filament-record-navigation.js'),
+        ], 'joseespinal/filament-record-navigation');
     }
 }

--- a/src/RecordNavigationServiceProvider.php
+++ b/src/RecordNavigationServiceProvider.php
@@ -23,7 +23,7 @@ class RecordNavigationServiceProvider extends PackageServiceProvider
     {
         // Register as a Filament asset
         FilamentAsset::register([
-            Js::make('filament-record-navigation', __DIR__ . '/../resources/dist/js/filament-record-navigation.js'),
+            Js::make('filament-record-navigation', __DIR__.'/../resources/dist/js/filament-record-navigation.js'),
         ], 'joseespinal/filament-record-navigation');
     }
 }

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -1,71 +1,129 @@
 <?php
 
+declare(strict_types=1);
+
 namespace JoseEspinal\RecordNavigation\Traits;
 
 use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
+use Filament\Resources\Pages\ViewRecord;
+use Livewire\Attributes\On;
+use Illuminate\Database\Eloquent\Model;
 
 trait HasRecordNavigation
 {
-    public $recordId;
+    use HasUnsavedDataChangesAlert;
 
-    public function mount($record): void
+    /**
+     * The current record ID being viewed/edited.
+     */
+    public string|int|null $recordId;
+
+    /**
+     * Whether the current page is a view record page.
+     */
+    public bool $isViewRecord = false;
+
+    /**
+     * The URL of the current record.
+     */
+    public string $url;
+
+    /**
+     * Mount the record navigation functionality.
+     */
+    public function mount(int|string $record): void
     {
-        $this->recordId = $record;
         parent::mount($record);
+        $this->initializeProperties($record);
+
+        $this->dispatch('start-record-navigation', [
+            'recordId' => $this->recordId,
+            'url' => $this->url,
+        ]);
     }
 
-    public function nextRecord()
+    public function nextRecord(): void
     {
         $ids = session('filament_record_navigation_ids');
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex + 1])) {
-            $nextId = $ids[$currentIndex + 1];
-            $url = route($this->getRouteName(), $nextId);
-
-            $this->recordId = $nextId;
-            $this->initializeRecord();
-            $this->mount($this->recordId);
-
-            $this->dispatch('nextRecord', [
-                'recordId' => $nextId,
-                'url' => $url,
-            ]);
+            $this->navigateToRecord($ids[$currentIndex + 1]);
         }
     }
 
-    public function previousRecord()
+    public function previousRecord(): void
     {
         $ids = session('filament_record_navigation_ids');
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex - 1])) {
-            $previousId = $ids[$currentIndex - 1];
-            $url = route($this->getRouteName(), $previousId);
-
-            $this->recordId = $previousId;
-            $this->initializeRecord();
-            $this->mount($this->recordId);
-
-            $this->dispatch('previousRecord', [
-                'recordId' => $previousId,
-                'url' => $url,
-            ]);
+            $this->navigateToRecord($ids[$currentIndex - 1]);
         }
     }
 
-    public function initializeRecord()
+    /**
+     * Handle the navigation to a specific record.
+     */
+    protected function navigateToRecord(string|int $recordId): void
+    {
+        $this->dispatch('changeNavigationRecord', [
+            'recordId' => $recordId,
+            'url' => $this->url,
+            'isViewRecord' => $this->isViewRecord,
+            'componentId' => $this->getId(),
+            'confirmMessage' => __('filament-panels::unsaved-changes-alert.body'),
+        ]);
+
+        $this->mountHasUnsavedDataChangesAlert();
+    }
+
+    /**
+     * Execute the record change after confirmation.
+     */
+    #[On('execute-change-record')]
+    public function executeChangeRecord(int|string $recordId): void
+    {
+        $this->recordId = $recordId;
+        $this->initializeComponentRecordProperty();
+        $this->initializeProperties($this->recordId);
+    }
+
+
+    private function initializeProperties(int|string $recordId): void
+    {
+        $this->recordId = $recordId;
+        $this->isViewRecord = $this instanceof ViewRecord;
+        $this->url = route($this->getRouteName(), ['record' => $recordId]);
+        $this->mountHasUnsavedDataChangesAlert();
+        parent::mount($this->recordId);
+    }
+
+    /**
+     * Initialize the record instance.
+     */
+    private function initializeComponentRecordProperty(): void
     {
         $this->record = $this->loadModel();
     }
 
-    protected function loadModel()
+    /**
+     * Load the model instance for the current record.
+     */
+    private function loadModel(): Model
     {
         $modelClass = static::$resource::getModel();
 
         return $modelClass::find($this->recordId);
     }
 
+    /**
+     * Get the navigation actions for the header.
+     *
+     * @return array<Action>
+     */
     protected function getNavigationActions(): array
     {
         return array_merge(parent::getHeaderActions(), [

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -2,7 +2,7 @@
 
 namespace JoseEspinal\RecordNavigation\Traits;
 
-use Filament\Pages\Actions\Action;
+use Filament\Actions\Action;
 
 trait HasRecordNavigation
 {
@@ -20,9 +20,17 @@ trait HasRecordNavigation
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex + 1])) {
-            $this->recordId = $ids[$currentIndex + 1];
+            $nextId = $ids[$currentIndex + 1];
+            $url = route($this->getRouteName(), $nextId);
+
+            $this->recordId = $nextId;
             $this->initializeRecord();
             $this->mount($this->recordId);
+
+            $this->dispatch('nextRecord', [
+                'recordId' => $nextId,
+                'url' => $url,
+            ]);
         }
     }
 
@@ -32,9 +40,17 @@ trait HasRecordNavigation
         $currentIndex = array_search($this->recordId, $ids);
 
         if ($currentIndex !== false && isset($ids[$currentIndex - 1])) {
-            $this->recordId = $ids[$currentIndex - 1];
+            $previousId = $ids[$currentIndex - 1];
+            $url = route($this->getRouteName(), $previousId);
+
+            $this->recordId = $previousId;
             $this->initializeRecord();
             $this->mount($this->recordId);
+
+            $this->dispatch('previousRecord', [
+                'recordId' => $previousId,
+                'url' => $url,
+            ]);
         }
     }
 

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -77,7 +77,7 @@ trait HasRecordNavigation
             'url' => $this->url,
             'isViewPage' => $this->isViewPage,
             'confirmMessage' => __('filament-panels::unsaved-changes-alert.body'),
-            'isDataDirty' => $this->isDataDirty
+            'isDataDirty' => $this->isDataDirty,
         ]);
     }
 

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -135,17 +135,29 @@ trait HasRecordNavigation
      */
     protected function getNavigationActions(): array
     {
+        $isSessionSet = session()->has('filament_record_navigation_ids');
+
         return array_merge(parent::getHeaderActions(), [
             Action::make('Previous')
                 ->action('previousRecord')
                 ->color('gray')
                 ->icon('heroicon-s-chevron-left')
-                ->iconButton(),
+                ->iconButton()
+                ->extraAttributes([
+                    'data-record-navigation-buttons' => true,
+                    'data-record-navigation-previous' => true,
+                ])
+                ->visible($isSessionSet),
             Action::make('Next')
                 ->action('nextRecord')
                 ->color('gray')
                 ->icon('heroicon-s-chevron-right')
-                ->iconButton(),
+                ->iconButton()
+                ->extraAttributes([
+                    'data-record-navigation-buttons' => true,
+                    'data-record-navigation-next' => true,
+                ])
+                ->visible($isSessionSet),
         ]);
     }
 }

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace JoseEspinal\RecordNavigation\Traits;
 
 use Filament\Actions\Action;
-use Filament\Facades\Filament;
 use Filament\Pages\Concerns\HasUnsavedDataChangesAlert;
 use Filament\Resources\Pages\ViewRecord;
-use Livewire\Attributes\On;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\On;
 
 trait HasRecordNavigation
 {
@@ -90,7 +89,6 @@ trait HasRecordNavigation
         $this->initializeComponentRecordProperty();
         $this->initializeProperties($this->recordId);
     }
-
 
     private function initializeProperties(int|string $recordId): void
     {

--- a/src/Traits/HasRecordsList.php
+++ b/src/Traits/HasRecordsList.php
@@ -17,6 +17,13 @@ trait HasRecordsList
             );
         }
 
+        $direction = $this->tableSortDirection ?? $this->getTable()->getDefaultSortDirection() ?? 'asc';
+        $sort = $this->tableSortColumn ?? $this->getTable()->getDefaultSort($query, $direction);
+
+        if ($direction) {
+            $query->orderBy($sort, $direction);
+        }
+
         // Store record IDs in session
         session(['filament_record_navigation_ids' => $query->pluck('id')->toArray()]);
 

--- a/src/Traits/HasRecordsList.php
+++ b/src/Traits/HasRecordsList.php
@@ -17,6 +17,9 @@ trait HasRecordsList
             );
         }
 
+        $model = static::getResource()::getModel();
+        $routeKeyName = (new $model)->getRouteKeyName() ?? 'id';
+
         $direction = $this->tableSortDirection ?? $this->getTable()->getDefaultSortDirection() ?? 'asc';
         $sort = $this->tableSortColumn ?? $this->getTable()->getDefaultSort($query, $direction);
 
@@ -25,7 +28,7 @@ trait HasRecordsList
         }
 
         // Store record IDs in session
-        session(['filament_record_navigation_ids' => $query->pluck('id')->toArray()]);
+        session(['filament_record_navigation_ids' => $query->pluck($routeKeyName)->toArray()]);
 
         return $query;
     }

--- a/src/Traits/HasRecordsList.php
+++ b/src/Traits/HasRecordsList.php
@@ -20,7 +20,7 @@ trait HasRecordsList
         $direction = $this->tableSortDirection ?? $this->getTable()->getDefaultSortDirection() ?? 'asc';
         $sort = $this->tableSortColumn ?? $this->getTable()->getDefaultSort($query, $direction);
 
-        if ($direction) {
+        if ($sort) {
             $query->orderBy($sort, $direction);
         }
 


### PR DESCRIPTION
# From the CHANGELOG:

### Added
- Enhanced record navigation actions with session-based visibility
- Added data change tracking and confirmation dialog for unsaved changes
- Added CSS attributes for easier styling of navigation buttons

### Changed
- Renamed event listeners for consistency and clarity
- Updated properties to better reflect their purpose, including changing `isViewRecord` to `isViewPage`
- Improved documentation to clarify customization of unsaved changes confirmation message

### Dev
- Updated GitHub Actions workflow to include Filament 3.0 in test matrix