### PR TITLE
Feature: Add support for relation managers refresh and update UI/UX stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `filament-record-navigation` will be documented in this file.
 
+## v2.2.0 - 2025-04-13
+
+### Added
+- Added support for relation managers refresh when navigating between records
+- Added new trait `HasRelationManagersWithRecordNavigation` for relation managers
+- Implemented auto-reload for relation managers via Livewire events
+
+### Changed
+- Refactored record initialization to use existing Filament methods
+- Improved handling of record changes to ensure relation managers stay in sync
+- Optimized record loading process
+
+**Full Changelog**: https://github.com/josespinal/filament-record-navigation/compare/v2.1.0...v2.2.0
+
 ## v2.1.0 - 2025-04-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://github.com/josespinal/filament-record-navigation/assets/10059/fbb09144-b
 - Unsaved changes detection with confirmation dialog
 - Browser history management for proper navigation state
 - Seamless URL updates without page refresh
+- Automatic relation managers refresh when navigating between records
 - Support for Laravel 10, 11, and 12
 - Compatible with Filament v3.x
 
@@ -95,6 +96,26 @@ class ListPosts extends ListRecords
     use HasRecordsList;
 
     protected static string $resource = PostResource::class;
+}
+```
+
+### Enable Relation Managers Refresh
+
+To automatically refresh relation managers when navigating between records, use the `HasRelationManagersWithRecordNavigation` trait in your relation managers:
+
+```php
+namespace App\Filament\Resources\PostResource\RelationManagers;
+
+use Filament\Resources\RelationManagers\RelationManager;
+use JoseEspinal\RecordNavigation\Traits\HasRelationManagersWithRecordNavigation;
+
+class CommentsRelationManager extends RelationManager
+{
+    use HasRelationManagersWithRecordNavigation;
+
+    protected static string $relationship = 'comments';
+    
+    // Rest of your relation manager code...
 }
 ```
 

--- a/resources/dist/js/filament-record-navigation.js
+++ b/resources/dist/js/filament-record-navigation.js
@@ -1,6 +1,6 @@
 // When the user navigates to the first record, 
 // we need to set the browser history
-document.addEventListener('startRecordNavigation', (event) => {
+document.addEventListener('recordNavigation.startRecordNavigation', (event) => {
   const { recordId, url } = event.detail[0];
   window.history.replaceState({ recordId }, '', url);
 });
@@ -9,25 +9,25 @@ document.addEventListener('startRecordNavigation', (event) => {
 // we need to update the record
 window.addEventListener("popstate", (event) => {
   if (event.state) {
-    Livewire.dispatch('executeChangeRecord', { 'recordId': event.state.recordId });
+    Livewire.dispatch('recordNavigation.executeChangeRecord', { 'recordId': event.state.recordId });
   }
 });
 
 // When the user navigates to a new record with the filament navigation, 
 // we need to update the browser history
-document.addEventListener('changeNavigationRecord', (event) => {
+document.addEventListener('recordNavigation.changeNavigationRecord', (event) => {
   const { recordId, url, isViewPage, confirmMessage, isDataDirty } = event.detail[0];
 
   if (!isViewPage) {
     if (isDataDirty) {
       if (confirm(confirmMessage)) {
         window.history.pushState({ recordId }, '', url);
-        Livewire.dispatch('executeChangeRecord', { 'recordId': recordId });
+        Livewire.dispatch('recordNavigation.executeChangeRecord', { 'recordId': recordId });
       }
       return;
     }
   }
 
   window.history.pushState({ recordId }, '', url);
-  Livewire.dispatch('executeChangeRecord', { 'recordId': recordId });
+  Livewire.dispatch('recordNavigation.executeChangeRecord', { 'recordId': recordId });
 }); 

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -6,7 +6,6 @@ namespace JoseEspinal\RecordNavigation\Traits;
 
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ViewRecord;
-use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\On;
 
 trait HasRecordNavigation

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -115,17 +115,10 @@ trait HasRecordNavigation
      */
     protected function initializeComponentRecordProperty(): void
     {
-        $this->record = $this->loadModel();
-    }
-
-    /**
-     * Load the model instance for the current record.
-     */
-    protected function loadModel(): Model
-    {
-        $modelClass = static::$resource::getModel();
-
-        return $modelClass::find($this->recordId);
+        $this->record = $this->resolveRecord($this->recordId);
+        $this->authorizeAccess();
+        $this->fillForm();
+        $this->dispatch('recordNavigation.reloadRelationManagers', recordId: $this->recordId);
     }
 
     /**

--- a/src/Traits/HasRelationManagersWithRecordNavigation.php
+++ b/src/Traits/HasRelationManagersWithRecordNavigation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JoseEspinal\RecordNavigation\Traits;
+
+use Livewire\Attributes\On;
+
+trait HasRelationManagersWithRecordNavigation
+{
+  #[On('recordNavigation.reloadRelationManagers')]
+  public function refreshRelationManager($recordId)
+  {
+    $model = resolve($this->ownerRecord->getModel()::class);
+    $newRecord = $model->find($recordId);
+    $this->ownerRecord = $newRecord;
+  }
+}

--- a/src/Traits/HasRelationManagersWithRecordNavigation.php
+++ b/src/Traits/HasRelationManagersWithRecordNavigation.php
@@ -6,11 +6,11 @@ use Livewire\Attributes\On;
 
 trait HasRelationManagersWithRecordNavigation
 {
-  #[On('recordNavigation.reloadRelationManagers')]
-  public function refreshRelationManager($recordId)
-  {
-    $model = resolve($this->ownerRecord->getModel()::class);
-    $newRecord = $model->find($recordId);
-    $this->ownerRecord = $newRecord;
-  }
+    #[On('recordNavigation.reloadRelationManagers')]
+    public function refreshRelationManager($recordId)
+    {
+        $model = resolve($this->ownerRecord->getModel()::class);
+        $newRecord = $model->find($recordId);
+        $this->ownerRecord = $newRecord;
+    }
 }

--- a/src/Traits/HasRelationManagersWithRecordNavigation.php
+++ b/src/Traits/HasRelationManagersWithRecordNavigation.php
@@ -6,6 +6,11 @@ use Livewire\Attributes\On;
 
 trait HasRelationManagersWithRecordNavigation
 {
+    public static function isLazy(): bool
+    {
+        return false;
+    }
+
     #[On('recordNavigation.reloadRelationManagers')]
     public function refreshRelationManager($recordId)
     {


### PR DESCRIPTION
## Description

This pull request adds support for refreshing relation managers when navigating between records in Filament.

### Features Added
- Added new trait `HasRelationManagersWithRecordNavigation` for relation managers
- Implemented auto-reload for relation managers via Livewire events
- Updated documentation to include instructions on how to use the new feature

### Changes
- Refactored record initialization to use existing Filament methods
- Improved handling of record changes to ensure relation managers stay in sync
- Updated README.md with new feature documentation
- Updated CHANGELOG.md for version 2.2.0

### Breaking Changes
None. This is a backward-compatible enhancement.

### Additional Notes
The feature allows for seamless relation manager updates when navigating between records, providing a better user experience. 