### PR TITLE
fix: improve record navigation handling in HasRecordNavigation trait

### DIFF
--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -131,10 +131,15 @@ trait HasRecordNavigation
     {
         $ids = session('filament_record_navigation_ids');
         $isSessionSet = session()->has('filament_record_navigation_ids');
-        $position = array_search($this->recordId, $ids);
+        $isPreviousDisabled = false;
+        $isNextDisabled = false;
 
-        $isPreviousDisabled = $position === 0;
-        $isNextDisabled = $position === count($ids) - 1;
+        if ($isSessionSet) {
+            $position = array_search($this->recordId, $ids);
+
+            $isPreviousDisabled = $position === 0;
+            $isNextDisabled = $position === count($ids) - 1;
+        }
 
         return [
             Action::make('Previous')


### PR DESCRIPTION
- Added a check to ensure session data is set before determining the position of the current record.
- Updated logic to disable navigation buttons based on the current record position only when session data is available.