### PR TITLE
Support RTL Navigation Icons & Safely Call ray() Function

### DIFF
--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -84,7 +84,9 @@ trait HasRecordNavigation
     public function updatedHasRecordNavigation($property): void
     {
         if (str_starts_with($property, 'data.')) {
-            ray($property);
+            if(function_exists('ray')) {
+                ray($property);
+            }
             $this->isDataDirty = true;
         }
     }

--- a/src/Traits/HasRecordNavigation.php
+++ b/src/Traits/HasRecordNavigation.php
@@ -6,6 +6,7 @@ namespace JoseEspinal\RecordNavigation\Traits;
 
 use Filament\Actions\Action;
 use Filament\Resources\Pages\ViewRecord;
+use Illuminate\Support\Facades\App;
 use Livewire\Attributes\On;
 
 trait HasRecordNavigation
@@ -141,11 +142,19 @@ trait HasRecordNavigation
         //     $isNextDisabled = $position === count($ids) - 1;
         // }
 
+        $naigation_previous_icon = App::isLocal('ar')
+            ? 'heroicon-s-chevron-right'
+            : 'heroicon-s-chevron-left';
+
+        $naigation_next_icon = App::isLocal('ar')
+            ? 'heroicon-s-chevron-left'
+            : 'heroicon-s-chevron-right';
+
         return [
             Action::make('Previous')
                 ->action('previousRecord')
                 ->color('gray')
-                ->icon('heroicon-s-chevron-left')
+                ->icon($naigation_previous_icon)
                 ->iconButton()
                 ->extraAttributes([
                     'data-record-navigation-buttons' => true,
@@ -155,7 +164,7 @@ trait HasRecordNavigation
             Action::make('Next')
                 ->action('nextRecord')
                 ->color('gray')
-                ->icon('heroicon-s-chevron-right')
+                ->icon($naigation_next_icon)
                 ->iconButton()
                 ->extraAttributes([
                     'data-record-navigation-buttons' => true,


### PR DESCRIPTION
## Summary

This PR introduces two key improvements:

1. Adjusts navigation button icons to correctly support RTL (Right-to-Left) locales, such as Arabic.
2. Adds a safety check before calling the `ray()` debugging function to avoid errors when the function is unavailable.

---

## Changes

### 1. RTL Navigation Icon Adjustment

- Dynamically sets the `Previous` and `Next` navigation icons based on the current app locale using `App::isLocale('ar')`.
- In RTL locales (e.g., Arabic):
  - `Previous` button uses `heroicon-s-chevron-right`
  - `Next` button uses `heroicon-s-chevron-left`
- In LTR locales (default behavior):
  - `Previous` button uses `heroicon-s-chevron-left`
  - `Next` button uses `heroicon-s-chevron-right`

### 2. Safe Use of `ray()` Debugging Tool

- Adds a conditional check to ensure the `ray()` function is only called if it exists.
- Prevents runtime errors in environments where the Ray debugger is not installed.

---

## Why

- **RTL Support**: Enhances usability for RTL users by aligning navigation icons with natural reading direction.
- **Robust Debugging**: Prevents potential crashes by ensuring `ray()` is only called in environments that support it.

---

## Example

| Locale     | Previous Icon               | Next Icon                    |
|------------|-----------------------------|------------------------------|
| `en` (LTR) | `heroicon-s-chevron-left`   | `heroicon-s-chevron-right`   |
| `ar` (RTL) | `heroicon-s-chevron-right`  | `heroicon-s-chevron-left`    |

---

## Notes

These updates enhance both user experience and code safety, with no breaking changes introduced.
